### PR TITLE
Specify types location in exports field of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
       {
         "import": "./dist/index.es.js",
         "require": "./dist/index.cjs.js",
-        "default": "./dist/index.cjs.js"
+        "default": "./dist/index.cjs.js",
+        "types": "./dist/index.d.ts"
       }
     ],
     "./package.json": "./package.json"


### PR DESCRIPTION
Updated the package.json to specify a `types` location in its `exports` field.  

fixes #10 